### PR TITLE
The user can optionally use Alien::Keystone to install keystone engine libraries

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -3,11 +3,21 @@ use ExtUtils::MakeMaker;
 
 # See lib/ExtUtils/MakeMaker.pm for details of how to influence
 # the contents of the Makefile that is written.
-my $cflags = `pkg-config --cflags keystone`;
-chomp $cflags if $cflags;
-my $define = '-DKEYSTONE_FROM_PKGCONFIG' if $cflags;
-my $ldflags = `pkg-config --libs keystone` || '-lkeystone';
-chomp $ldflags if $ldflags;
+
+# use Alien::Keystone to install Keystone safely just for Perl usage
+my ($cflags, $ldflags, $define) = ();
+if (eval { require Alien::Keystone; 1 }) {
+    my $capstone = Alien::Keystone->new;
+    $cflags = $capstone->cflags;
+    $ldflags = $capstone->libs;
+    $define = '-DCAPSTONE_FROM_PKGCONFIG';
+} else {
+    $cflags = `pkg-config --cflags keystone`;
+    chomp $cflags if $cflags;
+    $define = '-DKEYSTONE_FROM_PKGCONFIG' if $cflags;
+    $ldflags = `pkg-config --libs keystone` || '-lkeystone';
+    chomp $ldflags if $ldflags;
+}
 
 WriteMakefile(
     NAME              => 'Keystone',


### PR DESCRIPTION
The user can optionally use Alien::Keystone to build and install keystone engine libraries specifically for use by the Perl Keystone module.